### PR TITLE
fix #16 - return instead of commitDone

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ var app = express();
 var bodyParser = require('body-parser')
 var requests = require('./request.js');
 
+// TODO: deprecated bodyParser: use individual json/urlencoded middlewares
 app.use(bodyParser())
 
 app.post('/hook', function(req,res){

--- a/request.js
+++ b/request.js
@@ -11,7 +11,7 @@ var token = "token "+process.env.OATH_TOKEN;
 
 var parseTODOS = function(url,cb){
 	// TODO: state should be referenced in the incoming url
-	request({url:url+"?state=all", headers: {'User-Agent': 'github-todo'}, function(err,res,body){
+	request({url:url+"?state=all", headers: {'User-Agent': 'github-todo'}}, function(err,res,body){
 		var issues = JSON.parse(body);
 		todos = []
 		issues.forEach(function(issue,index){
@@ -26,36 +26,26 @@ var parseTODOS = function(url,cb){
  */
 
 var parseCommits = function(url,commits,cb){
-	var comind = 0;
 	todos = [];
-  // TODO: replace commitDone counter with better loop logic
-	var commitDone = function(){
-		if(comind == 0){
-			cb(todos);
-		}
-	}
-	commits.forEach(function(commit,index){
-		comind++
+	commits.forEach(function(commit,commitIndex){
 		var thisUrl = url+commit
 		request({url:thisUrl, headers: {'User-Agent': 'github-todo'}}, function(err,res,body){
 			// TODO: watch err and parse as needed. 
 			var body = JSON.parse(body)
 			if(body.type!="file"){
-				comind--
-				commitDone()
+        return;
 			}
 			contents = new Buffer(body.content, 'base64');
 			contents = contents.toString();
 			lines = contents.split('\n')
-			lines.forEach(function(line,index){
+			lines.forEach(function(line,lineIndex){
 				if(line.indexOf('TODO:')>=0){
 					todo = line.split('TODO:')[1].trim()
 					todos.push(todo);
 				}
 			})
-			comind--
-			commitDone()
 		});
+    cb(todos);
 	})
 };
 


### PR DESCRIPTION
Hmm ... really wish we had a test around `parseCommits` so I could test this more easily. (I tried enabling issues on my own repo and adding my own heroku app as a web-hook, but it crashed?)

But, this is what I propose for #16 ... if it works.
